### PR TITLE
Fix binary generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,30 +10,27 @@ $ yarn install
 # Usage
 
 <!-- usage -->
-
 ```sh-session
 $ npm install -g sparta
 $ sparta COMMAND
 running command...
 $ sparta (-v|--version|version)
-sparta/1.0.0 darwin-x64 node-v14.6.0
+sparta/1.1.0 darwin-x64 node-v14.6.0
 $ sparta --help [COMMAND]
 USAGE
   $ sparta COMMAND
 ...
 ```
-
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-
-- [`sparta help [COMMAND]`](#sparta-help-command)
-- [`sparta init`](#sparta-init)
-- [`sparta sync`](#sparta-sync)
-- [`sparta today`](#sparta-today)
-- [`sparta test`](#sparta-test)
+* [`sparta help [COMMAND]`](#sparta-help-command)
+* [`sparta init`](#sparta-init)
+* [`sparta sync`](#sparta-sync)
+* [`sparta test`](#sparta-test)
+* [`sparta today`](#sparta-today)
 
 ## `sparta help [COMMAND]`
 
@@ -54,7 +51,7 @@ _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v3.2.0
 
 ## `sparta init`
 
-Initializes the Sparta workspace.
+Initializes the Sparta workspace
 
 ```
 USAGE
@@ -68,37 +65,38 @@ EXAMPLE
   $ sparta init
 ```
 
-There are two flags that are hidden from the help (because we don't want students to use them):
-
-- `--spartaURL="<url>"` will update the URL that will be called when talking to Sparta API.
-- `--force` or `-f` will recreate the exercises repository (deleting the previous folder, beware).
+_See code: [src/commands/init.ts](https://github.com/fewlinesco/sparta-cli/blob/v1.1.0/src/commands/init.ts)_
 
 ## `sparta sync`
 
-Updates all the courses for the past days.
+Updates all the exercises for the past days
 
 ```
 USAGE
   $ sparta sync
 ```
 
+_See code: [src/commands/sync.ts](https://github.com/fewlinesco/sparta-cli/blob/v1.1.0/src/commands/sync.ts)_
+
+## `sparta test`
+
+Launch the tests for an exercise
+
+```
+USAGE
+  $ sparta test
+```
+
+_See code: [src/commands/test.ts](https://github.com/fewlinesco/sparta-cli/blob/v1.1.0/src/commands/test.ts)_
+
 ## `sparta today`
 
-Downloads the exercises for the current day.
+Downloads the exercises for the current day
 
 ```
 USAGE
   $ sparta today
 ```
 
-## `sparta test`
-
-Replaces `yarn jest` and sends the results to Sparta.
-Arguments are sent as-is to `jest`.
-
-```
-USAGE
-  $ sparta test [--runInBand] [test-file]
-```
-
+_See code: [src/commands/today.ts](https://github.com/fewlinesco/sparta-cli/blob/v1.1.0/src/commands/today.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "oclif"
   ],
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "lib/index.js",
   "oclif": {
     "commands": "./lib/commands",
     "bin": "sparta",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sparta",
   "description": "Sparta CLI",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Fewlines",
   "bin": {
     "sparta": "./bin/run"
@@ -10,10 +10,11 @@
   "dependencies": {
     "@oclif/command": "^1",
     "@oclif/config": "^1",
+    "@oclif/dev-cli": "^1",
     "@oclif/plugin-help": "^3",
     "fs-extra": "^9.0.1",
-    "marked": "^1.1.1",
     "marked-terminal": "^4.1.0",
+    "marked": "^1.1.1",
     "node-emoji": "^1.10.0",
     "node-fetch": "^2.6.0",
     "simple-git": "^2.20.1",
@@ -21,7 +22,6 @@
   },
   "devDependencies": {
     "@fewlines/eslint-config": "^3.0.0",
-    "@oclif/dev-cli": "^1",
     "@types/fs-extra": "9.0.1",
     "@types/jest": "^26.0.10",
     "@types/marked": "1.1.0",
@@ -74,7 +74,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "oclif": {
-    "commands": "./dist/commands",
+    "commands": "./lib/commands",
     "bin": "sparta",
     "plugins": [
       "@oclif/plugin-help"
@@ -82,7 +82,7 @@
   },
   "repository": "fewlinesco/sparta-cli",
   "scripts": {
-    "postpack": "rm -f oclif.manifest.json",
+    "postpack": "rm -f oclif.manifest.json tsconfig.tsbuildinfo",
     "posttest": "eslint . --ext .ts",
     "prepack": "rm -rf dist && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "echo NO TESTS",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,12 @@
     "declaration": true,
     "importHelpers": true,
     "module": "commonjs",
-    "outDir": "dist",
+    "outDir": "lib",
     "rootDir": "src",
     "strict": true,
-    "target": "es2019",
+    "target": "es2019"
   },
   "include": [
-    "src/**/*",
+    "src/**/*"
   ]
 }


### PR DESCRIPTION
## Description

This PR fixes some issues that resulted in a bug with the binary:
- the TS is compiled to `lib` instead of `dist` because `dist` is used to generate binaries,
- the commands are located in this `lib` folder,
- `@oclif-dev` is now a dependency to avoid missing a dependency missing in the final build.

This also updates the README with the auto generated one.

## How Has This Been Tested?

By pushing and testing a bunch of things to brew

## Types of changes

- ~Chore (non-breaking change which refactors / improves the existing code base)~
- Bug fix (non-breaking change which fixes an issue)
- ~New feature (non-breaking change which adds functionality)~
- ~Breaking change (fix or feature that would cause existing functionality to 
  change)~

## Checklist:

- ✅ : My code follows the code style of this project.
- ✅: My change requires a change to the documentation.
- ✅: I have updated the documentation accordingly.
- ✅ I have read the [**CONTRIBUTING**][CONTRIBUTING_FILE] document.
- 🔴 : I have added tests to cover my changes.
- ✅ : All new and existing tests passed.

[CONTRIBUTING_FILE]: https://github.com/fewlinesco/guidelines/blob/master/CONTRIBUTING.adoc
