### PR TITLE
Fix sync command for 'empty' days

### DIFF
--- a/src/services/fetch-past-days-exercises-paths.ts
+++ b/src/services/fetch-past-days-exercises-paths.ts
@@ -27,7 +27,9 @@ export default async function fetchPastDaysExercisesPaths(
     throw new CalendarFetchError(error.message);
   }
 
-  const paths = findPastDaysExercisesPaths(calendar);
+  const paths = findPastDaysExercisesPaths(calendar).filter(
+    (path) => path !== "",
+  );
 
   return paths;
 }


### PR DESCRIPTION
## Description

This PR fixes a little thing that can occur if we have "empty" days in the calendar (days that have no `path` assigned to them, like with a week off).

## Motivation and Context

Without this change, we have empty strings when looking for all the paths to update and we then create a whole new repo in `<root>/current` :/

## How Has This Been Tested?

Manually

## Types of changes

- ~Chore (non-breaking change which refactors / improves the existing code base)~
- Bug fix (non-breaking change which fixes an issue)
- ~New feature (non-breaking change which adds functionality)~
- ~Breaking change (fix or feature that would cause existing functionality to 
  change)~

## Checklist:

- ✅ : My code follows the code style of this project.
- 🔴 : My change requires a change to the documentation.
- 🔴 : I have updated the documentation accordingly.
- ✅ : I have read the [**CONTRIBUTING**][CONTRIBUTING_FILE] document.
- 🔴 : I have added tests to cover my changes.
- ✅ : All new and existing tests passed.

[CONTRIBUTING_FILE]: https://github.com/fewlinesco/guidelines/blob/master/CONTRIBUTING.adoc
